### PR TITLE
Tables - Drop unneeded columns storing duplicate geolocation information

### DIFF
--- a/snowexsql/tables/base.py
+++ b/snowexsql/tables/base.py
@@ -30,12 +30,7 @@ class SingleLocationData(SnowData):
     """
     Base class for points and profiles
     """
-    latitude = Column(Float)
-    longitude = Column(Float)
-    northing = Column(Float)
-    easting = Column(Float)
     elevation = Column(Float)
-    utm_zone = Column(Integer)
     geom = Column(Geometry("POINT"))
     time = Column(Time(timezone=True))
     site_id = Column(String(50))

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -10,7 +10,7 @@ from .sql_test_base import DBSetup
 
 class TestDB(DBSetup):
     base_atts = ['site_name', 'date', 'site_id']
-    single_loc_atts = ['latitude', 'longitude', 'easting', 'elevation', 'utm_zone', 'geom', 'time']
+    single_loc_atts = ['elevation', 'geom', 'time']
 
     meas_atts = ['instrument', 'type', 'units', 'observers']
 
@@ -25,8 +25,8 @@ class TestDB(DBSetup):
                  ['version_number', 'equipment', 'value']
 
     layer_atts = single_loc_atts + meas_atts + \
-                 ['depth', 'value', 'bottom_depth', 'comments', 'sample_a', 'sample_b',
-                  'sample_c']
+                 ['depth', 'value', 'bottom_depth', 'comments', 'sample_a',
+                  'sample_b', 'sample_c']
     raster_atts = meas_atts + ['raster', 'description']
 
     def setup_class(self):


### PR DESCRIPTION
The `geom` column has all the information for lat, lon, east. north, and utm_zone. Hence, we can drop these to reduce duplication.

Fixes #105
