### PR TITLE
build: Add CODEOWNERS for auto PR review to set of people

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @micah-prime @micahjohnson150 @jomey


### PR DESCRIPTION
## Overview

This PR adds the github CODEOWNERS file for a list of people that should be included as reviewers for each PR.
