### PR TITLE
Actions - Switch to use CodeCov to check test coverage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,0 @@
-![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/micahjohnson150/2034019acc40a963bd02d2fcbb31c5a9/raw/snowexsql__pull_##.json)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,43 @@
+name: Code Quality
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    services:
+      postgis:
+        image: kartoza/postgis:14-3.2
+        env:
+          POSTGRES_PASSWORD: db_builder
+          POSTGRES_USER: builder
+          POSTGRES_DB: test
+          TZ: 'UTC'
+          PGTZ: 'UTC'
+          POSTGIS_GDAL_ENABLED_DRIVERS: 'ENABLE_ALL'
+          POSTGIS_ENABLE_OUTDB_RASTERS: 'True'
+        ports:
+          - 5432:5432
+        volumes:
+          - /home/runner/work/:/home/runner/work/
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: python3 -m pip install -e ".[dev]"
+      - name: Run tests and collect coverage
+        run: pytest --cov snowexsql --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 
-name: snowexsql testing
+name: Pytest
 
 # Controls when the action will run.
 on:
@@ -46,44 +46,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y postgis gdal-bin
           python3 -m pip install --upgrade pip
-          python3 -m pip install pytest coverage
           python3 -m pip install -e ".[dev]"
       - name: Test with pytest
         run: |
           pytest -s
-
-      # Run coverage only once
-      - if: ${{ matrix.python-version == '3.9'}}
-        name: Get Coverage for badge
-        run: |
-          # Run coverage save the results
-          coverage run --source snowexsql -m pytest
-          SUMMARY=`coverage report -m | grep TOTAL`
-
-          # Save results as ENV var
-          COVERAGE=$(python -c "print('$SUMMARY'.split(' ')[-1])")
-          echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
-
-          # var REF = 'refs/pull/27/merge.json';
-          REF=${{ github.ref }}
-          # console.log('github.ref: ' + REF);
-          echo "github.ref: $REF"
-          # var PATHS = REF.split('/');
-          IFS='/' read -ra PATHS <<< "$REF"
-          # var BRANCH_NAME = PATHS[1] + PATHS[2];
-          BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
-          # console.log(BRANCH_NAME); // 'pull_27'
-          echo $BRANCH_NAME
-          # process.env.BRANCH = 'pull_27';
-          echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
-
-      - if: ${{ matrix.python-version == '3.9'}}
-        name: Create the Badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: 2034019acc40a963bd02d2fcbb31c5a9
-          filename: snowexsql__${{ env.BRANCH }}.json
-          label: Coverage
-          message: ${{ env.COVERAGE }}
-          color: green

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ Welcome to snowexsql
     :target: https://pypi.org/project/snowexsql/
     :alt: Code Coverage
 
-.. image:: https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/micahjohnson150/2034019acc40a963bd02d2fcbb31c5a9/raw/snowexsql__heads_master.json
-    :alt: Code Coverage
+.. image:: https://codecov.io/gh/SnowEx/snowexsql/graph/badge.svg?token=B27OKGBOTR
+    :target: https://codecov.io/gh/SnowEx/snowexsql
 
 About
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pip==23.3",
-    "coverage==5.5",
-    "pytest==6.2.4",
-    "pytest-cov==2.12.1",
+    "pytest",
+    "pytest-cov",
     "sphinx-autobuild<=2024.5",
 ]
 docs = [


### PR DESCRIPTION
Change the workflow to get test coverage and use the CodeCov service. This also separates the step into a dedicated CI action and independent of the Python 3.9 test runs. Upgrading the pytest and pytest-cov package to always use the latest.