### PR TITLE
GH actions - Exclude CI and main for 'docs' changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,12 @@ name: Code Quality
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,12 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [ master ]
-  workflow_dispatch:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   build:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,13 @@ build:
   tools:
     python: "3.11"
   jobs:
+    post_checkout:
+      # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- docs/ .readthedocs.yaml;
+        then
+          exit 183;
+        fi
     pre_build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.
       - "jupyter-book config sphinx docs"


### PR DESCRIPTION
Do not run the CI or main actions once there are only changes to documentation. On the other hand, trigger the docs only when there are changes to that.

Reference:
* https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-paths
* https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition