### PR TITLE
Campaign observations - Abstract Point and Image data metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "factory_boy<4",
+    "pytest-factoryboy<3",
     "pytest",
     "pytest-cov",
     "sphinx-autobuild<=2024.5",

--- a/snowexsql/api.py
+++ b/snowexsql/api.py
@@ -10,9 +10,8 @@ from sqlalchemy.sql import func
 
 from snowexsql.conversions import query_to_geopandas, raster_to_rasterio
 from snowexsql.db import get_db
-from snowexsql.tables import ImageData, LayerData, PointData, Instrument, \
-    Observer, Site, Campaign, MeasurementType, DOI
-
+from snowexsql.tables import Campaign, DOI, ImageData, Instrument, LayerData, \
+    MeasurementType, Observer, PointData, Site
 
 LOG = logging.getLogger(__name__)
 DB_NAME = 'snow:hackweek@db.snowexdata.org/snowex'
@@ -162,7 +161,7 @@ class BaseDataset:
                         ).filter(DOI.doi == v)
                     elif k == "type":
                         qry = qry.join(
-                            qry_model.measurement
+                            qry_model.measurement_type
                         ).filter(MeasurementType.name == v)
                     # Filter to exact value
                     else:

--- a/snowexsql/conversions.py
+++ b/snowexsql/conversions.py
@@ -3,7 +3,6 @@ Module contains all conversions used for manipulating data. This includes:
 filetypes, datatypes, etc. Many tools here will be useful for most end users
 of the database.
 """
-
 import geopandas as gpd
 import pandas as pd
 from geoalchemy2.shape import to_shape
@@ -54,8 +53,10 @@ def query_to_geopandas(query, engine, **kwargs):
     # Fill out the variables in the query
     sql = query.statement.compile(dialect=postgresql.dialect())
 
-    # Get dataframe from geopandas using the query and engine
-    df = gpd.GeoDataFrame.from_postgis(sql, engine, **kwargs)
+    # Get dataframe from geopandas using the query and the DB connection.
+    # By passing in the actual connection, we maintain ownership of it and
+    # keep it alive until we close it.
+    df = gpd.read_postgis(sql, engine.connect(), **kwargs)
 
     return df
 

--- a/snowexsql/tables/__init__.py
+++ b/snowexsql/tables/__init__.py
@@ -1,21 +1,25 @@
-from .image_data import ImageData
-from .layer_data import LayerData
-from .point_data import PointData
-from .observers import Observer
-from .instrument import Instrument
 from .campaign import Campaign
-from .site import Site
 from .doi import DOI
+from .image_data import ImageData
+from .image_observation import ImageObservation
+from .instrument import Instrument
+from .layer_data import LayerData
 from .measurement_type import MeasurementType
+from .observers import Observer
+from .point_data import PointData
+from .point_observation import PointObservation
+from .site import Site
 
 __all__ = [
     "Campaign",
     "DOI",
     "ImageData",
+    "ImageObservation",
     "Instrument",
     "LayerData",
     "MeasurementType",
     "Observer",
     "PointData",
+    "PointObservation",
     "Site",
 ]

--- a/snowexsql/tables/base.py
+++ b/snowexsql/tables/base.py
@@ -5,8 +5,7 @@ from Base is a real table in the database. This is called Object Relational
 Mapping in the sqlalchemy or ORM.
 """
 
-from geoalchemy2 import Geometry
-from sqlalchemy import Column, Float, Integer, Time, Date
+from sqlalchemy import Column, Date, Integer
 from sqlalchemy.orm import DeclarativeBase
 
 
@@ -18,15 +17,3 @@ class Base(DeclarativeBase):
     __table_args__ = {"schema": "public"}
     # Primary Key
     id = Column(Integer, primary_key=True)
-
-
-class SingleLocationData:
-    """
-    Base class for points and profiles
-    """
-    elevation = Column(Float)
-    geom = Column(Geometry("POINT"))
-    time = Column(Time(timezone=True))
-
-
-

--- a/snowexsql/tables/base.py
+++ b/snowexsql/tables/base.py
@@ -1,10 +1,3 @@
-"""
-Module contains all the data models for the database. Classes here actually
-represent tables where columns are mapped as attributed. Any class inheriting
-from Base is a real table in the database. This is called Object Relational
-Mapping in the sqlalchemy or ORM.
-"""
-
 from sqlalchemy import Column, Date, Integer
 from sqlalchemy.orm import DeclarativeBase
 

--- a/snowexsql/tables/campaign_observation.py
+++ b/snowexsql/tables/campaign_observation.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, ForeignKey, String, Text
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
 from .campaign import InCampaign
@@ -27,13 +27,9 @@ class CampaignObservation(
 
 class HasObservation:
     """
-    Class to inherit when adding a observer relationship to a table
+    Class to inherit when adding a observation relationship to a table
     """
 
     observation_id: Mapped[int] = mapped_column(
         ForeignKey("public.campaign_observations.id"), index=True
     )
-
-    @declared_attr
-    def observation(self):
-        return relationship('CampaignObservation')

--- a/snowexsql/tables/campaign_observation.py
+++ b/snowexsql/tables/campaign_observation.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, ForeignKey, String, Text
+from sqlalchemy import Column, Date, ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
@@ -20,6 +20,7 @@ class CampaignObservation(
     # Data columns
     name = Column(Text)
     description = Column(Text)
+    date = Column(Date, nullable=False)
 
     # Single Table Inheritance column
     type = Column(String, nullable=False)

--- a/snowexsql/tables/campaign_observation.py
+++ b/snowexsql/tables/campaign_observation.py
@@ -1,0 +1,39 @@
+from sqlalchemy import Column, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+
+from .base import Base
+from .campaign import InCampaign
+from .doi import HasDOI
+from .instrument import HasInstrument
+from .measurement_type import HasMeasurement
+from .observers import HasObserver
+
+
+class CampaignObservation(
+    Base, HasDOI, HasInstrument, HasMeasurement, HasObserver, InCampaign
+):
+    """
+    A campaign observation holds additional information for a point or image.
+    """
+    __tablename__ = 'campaign_observations'
+
+    # Data columns
+    name = Column(Text)
+    description = Column(Text)
+
+    # Single Table Inheritance column
+    type = Column(String, nullable=False)
+
+
+class HasObservation:
+    """
+    Class to inherit when adding a observer relationship to a table
+    """
+
+    observation_id: Mapped[int] = mapped_column(
+        ForeignKey("public.campaign_observations.id"), index=True
+    )
+
+    @declared_attr
+    def observation(self):
+        return relationship('CampaignObservation')

--- a/snowexsql/tables/campaign_observation.py
+++ b/snowexsql/tables/campaign_observation.py
@@ -24,6 +24,10 @@ class CampaignObservation(
     # Single Table Inheritance column
     type = Column(String, nullable=False)
 
+    __mapper_args__ = {
+        'polymorphic_on': type,
+    }
+
 
 class HasObservation:
     """

--- a/snowexsql/tables/campaign_observation.py
+++ b/snowexsql/tables/campaign_observation.py
@@ -5,12 +5,12 @@ from .base import Base
 from .campaign import InCampaign
 from .doi import HasDOI
 from .instrument import HasInstrument
-from .measurement_type import HasMeasurement
+from .measurement_type import HasMeasurementType
 from .observers import HasObserver
 
 
 class CampaignObservation(
-    Base, HasDOI, HasInstrument, HasMeasurement, HasObserver, InCampaign
+    Base, HasDOI, HasInstrument, HasMeasurementType, HasObserver, InCampaign
 ):
     """
     A campaign observation holds additional information for a point or image.

--- a/snowexsql/tables/image_data.py
+++ b/snowexsql/tables/image_data.py
@@ -1,5 +1,5 @@
 from geoalchemy2 import Raster
-from sqlalchemy import Column, Date, String
+from sqlalchemy import Column, String
 
 from .base import Base
 from .image_observation import HasImageObservation
@@ -10,7 +10,5 @@ class ImageData(Base, HasImageObservation):
     Class representing the images table. This table holds all images/rasters
     """
     __tablename__ = 'images'
-    # Date of the measurement
-    date = Column(Date)
     raster = Column(Raster)
     units = Column(String(50))

--- a/snowexsql/tables/image_data.py
+++ b/snowexsql/tables/image_data.py
@@ -1,14 +1,11 @@
 from geoalchemy2 import Raster
-from sqlalchemy import Column, String, Date
+from sqlalchemy import Column, Date, String
 
 from .base import Base
-from .campaign import InCampaign
-from .instrument import HasInstrument
-from .measurement_type import HasMeasurementType
-from .doi import HasDOI
+from .campaign_observation import HasObservation
 
 
-class ImageData(Base, HasMeasurementType, HasInstrument, HasDOI, InCampaign):
+class ImageData(Base, HasObservation):
     """
     Class representing the images table. This table holds all images/rasters
     """
@@ -16,5 +13,4 @@ class ImageData(Base, HasMeasurementType, HasInstrument, HasDOI, InCampaign):
     # Date of the measurement
     date = Column(Date)
     raster = Column(Raster)
-    description = Column(String())
     units = Column(String(50))

--- a/snowexsql/tables/image_data.py
+++ b/snowexsql/tables/image_data.py
@@ -2,10 +2,10 @@ from geoalchemy2 import Raster
 from sqlalchemy import Column, Date, String
 
 from .base import Base
-from .campaign_observation import HasObservation
+from .image_observation import HasImageObservation
 
 
-class ImageData(Base, HasObservation):
+class ImageData(Base, HasImageObservation):
     """
     Class representing the images table. This table holds all images/rasters
     """

--- a/snowexsql/tables/image_data.py
+++ b/snowexsql/tables/image_data.py
@@ -1,5 +1,5 @@
 from geoalchemy2 import Raster
-from sqlalchemy import Column, String
+from sqlalchemy import Column
 
 from .base import Base
 from .image_observation import HasImageObservation
@@ -11,4 +11,3 @@ class ImageData(Base, HasImageObservation):
     """
     __tablename__ = 'images'
     raster = Column(Raster)
-    units = Column(String(50))

--- a/snowexsql/tables/image_observation.py
+++ b/snowexsql/tables/image_observation.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import declared_attr, relationship
+from sqlalchemy.orm import Mapped, declared_attr, relationship
 
 from .campaign_observation import CampaignObservation, HasObservation
 
@@ -20,5 +20,5 @@ class HasImageObservation(HasObservation):
     Class to inherit when adding a observation relationship to a table
     """
     @declared_attr
-    def observation(self):
+    def observation(self) -> Mapped[ImageObservation]:
         return relationship("ImageObservation")

--- a/snowexsql/tables/image_observation.py
+++ b/snowexsql/tables/image_observation.py
@@ -1,4 +1,6 @@
-from .campaign_observation import CampaignObservation
+from sqlalchemy.orm import declared_attr, relationship
+
+from .campaign_observation import CampaignObservation, HasObservation
 
 
 class ImageObservation(CampaignObservation):
@@ -8,6 +10,15 @@ class ImageObservation(CampaignObservation):
     """
     # Single Table Inheritance identifier
     __mapper_args__ = {
-        'polymorphic_on': type,
+        'polymorphic_on': "type",
         'polymorphic_identity': 'ImageObservation'
     }
+
+
+class HasImageObservation(HasObservation):
+    """
+    Class to inherit when adding a observation relationship to a table
+    """
+    @declared_attr
+    def observation(self):
+        return relationship("ImageObservation")

--- a/snowexsql/tables/image_observation.py
+++ b/snowexsql/tables/image_observation.py
@@ -10,8 +10,8 @@ class ImageObservation(CampaignObservation):
     """
     # Single Table Inheritance identifier
     __mapper_args__ = {
-        'polymorphic_on': "type",
-        'polymorphic_identity': 'ImageObservation'
+        'polymorphic_identity': 'ImageObservation',
+        'polymorphic_load': 'inline',
     }
 
 

--- a/snowexsql/tables/image_observation.py
+++ b/snowexsql/tables/image_observation.py
@@ -1,0 +1,13 @@
+from .campaign_observation import CampaignObservation
+
+
+class ImageObservation(CampaignObservation):
+    """
+    Class to hold specific methods to query image observations from
+    the campaign_observations table
+    """
+    # Single Table Inheritance identifier
+    __mapper_args__ = {
+        'polymorphic_on': type,
+        'polymorphic_identity': 'ImageObservation'
+    }

--- a/snowexsql/tables/measurement_type.py
+++ b/snowexsql/tables/measurement_type.py
@@ -1,5 +1,5 @@
-from sqlalchemy import Boolean, Column, Text, Integer, ForeignKey
-from sqlalchemy.orm import relationship, declared_attr
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, Text
+from sqlalchemy.orm import declared_attr, relationship
 
 from .base import Base
 
@@ -15,17 +15,17 @@ class MeasurementType(Base):
     derived = Column(Boolean, default=False)
 
 
-
 class HasMeasurementType:
     """
     Class to extend when including a measurement type
     """
 
     @declared_attr
-    def measurement_type_id(cls):
-        return Column(Integer, ForeignKey('public.measurement_type.id'),
-                      index=True)
+    def measurement_type_id(self):
+        return Column(
+            Integer, ForeignKey('public.measurement_type.id'), index=True
+        )
 
     @declared_attr
-    def measurement(cls):
+    def measurement_type(self):
         return relationship('MeasurementType')

--- a/snowexsql/tables/observers.py
+++ b/snowexsql/tables/observers.py
@@ -1,5 +1,5 @@
-from sqlalchemy.orm import mapped_column, Mapped
-from sqlalchemy import Column, String
+from sqlalchemy import Column, ForeignKey, String
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from .base import Base
 
@@ -10,3 +10,17 @@ class Observer(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     # Name of the observer
     name = Column(String())
+
+
+class HasObserver:
+    """
+    Class to inherit when adding a observer relationship to a table
+    """
+
+    observers_id: Mapped[int] = mapped_column(
+        ForeignKey("public.observers.id"), index=True
+    )
+
+    @declared_attr
+    def observer(self):
+        return relationship('Observer')

--- a/snowexsql/tables/point_data.py
+++ b/snowexsql/tables/point_data.py
@@ -2,12 +2,13 @@ from sqlalchemy import Column, Float, Integer, String, ForeignKey, Date
 from sqlalchemy.orm import Mapped, relationship, mapped_column
 from typing import List
 
-from .base import Base, SingleLocationData
+from .base import Base
 from .campaign import InCampaign
 from .doi import HasDOI
+from .instrument import HasInstrument
 from .measurement_type import HasMeasurementType
 from .observers import Observer
-from .instrument import HasInstrument
+from .single_location import SingleLocationData
 
 
 class PointObservers(Base):

--- a/snowexsql/tables/point_data.py
+++ b/snowexsql/tables/point_data.py
@@ -1,30 +1,11 @@
-from sqlalchemy import Column, Float, Integer, String, ForeignKey, Date
-from sqlalchemy.orm import Mapped, relationship, mapped_column
-from typing import List
+from sqlalchemy import Column, Date, Float, Integer, String
 
 from .base import Base
-from .campaign import InCampaign
-from .doi import HasDOI
-from .instrument import HasInstrument
-from .measurement_type import HasMeasurementType
-from .observers import Observer
+from .campaign_observation import HasObservation
 from .single_location import SingleLocationData
 
 
-class PointObservers(Base):
-    """
-    Link table
-    """
-    __tablename__ = 'point_observers'
-
-    point_id = Column(Integer, ForeignKey('public.points.id'))
-    observer_id = Column(Integer, ForeignKey("public.observers.id"))
-
-
-class PointData(
-    SingleLocationData, HasMeasurementType, HasInstrument, Base, HasDOI,
-    InCampaign
-):
+class PointData(Base, SingleLocationData, HasObservation):
     """
     Class representing the points table. This table holds all point data.
     Here a single data entry is a single coordinate pair with a single value
@@ -41,9 +22,3 @@ class PointData(
 
     # bring these in instead of Measurement
     units = Column(String())
-
-    # id is a mapped column for many-to-many with observers
-    id: Mapped[int] = mapped_column(primary_key=True)
-    observers: Mapped[List[Observer]] = relationship(
-        secondary=PointObservers.__table__
-    )

--- a/snowexsql/tables/point_data.py
+++ b/snowexsql/tables/point_data.py
@@ -1,11 +1,11 @@
 from sqlalchemy import Column, Date, Float, Integer, String
 
 from .base import Base
-from .campaign_observation import HasObservation
+from .point_observation import HasPointObservation
 from .single_location import SingleLocationData
 
 
-class PointData(Base, SingleLocationData, HasObservation):
+class PointData(Base, SingleLocationData, HasPointObservation):
     """
     Class representing the points table. This table holds all point data.
     Here a single data entry is a single coordinate pair with a single value

--- a/snowexsql/tables/point_data.py
+++ b/snowexsql/tables/point_data.py
@@ -1,4 +1,5 @@
-from sqlalchemy import Column, Date, Float, Integer, String
+from sqlalchemy import Column, DateTime, Float, Integer, String
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from .base import Base
 from .point_observation import HasPointObservation
@@ -13,8 +14,8 @@ class PointData(Base, SingleLocationData, HasPointObservation):
     """
     __tablename__ = 'points'
 
-    # Date of the measurement
-    date = Column(Date)
+    # Date of the measurement with time
+    date = Column(DateTime)
 
     version_number = Column(Integer)
     equipment = Column(String())

--- a/snowexsql/tables/point_data.py
+++ b/snowexsql/tables/point_data.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, Float, Integer, String
+from sqlalchemy import Column, Date, DateTime, Float, Integer, String
 from sqlalchemy.ext.hybrid import hybrid_property
 
 from .base import Base
@@ -23,3 +23,17 @@ class PointData(Base, SingleLocationData, HasPointObservation):
 
     # bring these in instead of Measurement
     units = Column(String())
+
+    @hybrid_property
+    def date_only(self):
+        """
+        Helper attribute to only query for dates of measurements
+        """
+        return self.date.date()
+
+    @date_only.expression
+    def date_only(cls):
+        """
+        Helper attribute to only query for dates of measurements
+        """
+        return cls.date.cast(Date)

--- a/snowexsql/tables/point_observation.py
+++ b/snowexsql/tables/point_observation.py
@@ -1,4 +1,6 @@
-from .campaign_observation import CampaignObservation
+from sqlalchemy.orm import declared_attr, relationship
+
+from .campaign_observation import CampaignObservation, HasObservation
 
 
 class PointObservation(CampaignObservation):
@@ -8,6 +10,15 @@ class PointObservation(CampaignObservation):
     """
     # Single Table Inheritance identifier
     __mapper_args__ = {
-        'polymorphic_on': type,
+        'polymorphic_on': "type",
         'polymorphic_identity': 'PointObservation'
     }
+
+
+class HasPointObservation(HasObservation):
+    """
+    Class to inherit when adding a observation relationship to a table
+    """
+    @declared_attr
+    def observation(self):
+        return relationship("PointObservation")

--- a/snowexsql/tables/point_observation.py
+++ b/snowexsql/tables/point_observation.py
@@ -10,8 +10,8 @@ class PointObservation(CampaignObservation):
     """
     # Single Table Inheritance identifier
     __mapper_args__ = {
-        'polymorphic_on': "type",
-        'polymorphic_identity': 'PointObservation'
+        'polymorphic_identity': 'PointObservation',
+        'polymorphic_load': 'inline',
     }
 
 

--- a/snowexsql/tables/point_observation.py
+++ b/snowexsql/tables/point_observation.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import declared_attr, relationship
+from sqlalchemy.orm import Mapped, declared_attr, relationship
 
 from .campaign_observation import CampaignObservation, HasObservation
 
@@ -20,5 +20,5 @@ class HasPointObservation(HasObservation):
     Class to inherit when adding a observation relationship to a table
     """
     @declared_attr
-    def observation(self):
+    def observation(self) -> Mapped[PointObservation]:
         return relationship("PointObservation")

--- a/snowexsql/tables/point_observation.py
+++ b/snowexsql/tables/point_observation.py
@@ -1,0 +1,13 @@
+from .campaign_observation import CampaignObservation
+
+
+class PointObservation(CampaignObservation):
+    """
+    Class to hold specific methods to query points observations from
+    the campaign_observations table
+    """
+    # Single Table Inheritance identifier
+    __mapper_args__ = {
+        'polymorphic_on': type,
+        'polymorphic_identity': 'PointObservation'
+    }

--- a/snowexsql/tables/single_location.py
+++ b/snowexsql/tables/single_location.py
@@ -1,0 +1,11 @@
+from geoalchemy2 import Geometry
+from sqlalchemy import Column, Float, Time
+
+
+class SingleLocationData:
+    """
+    Base class for point and layer data
+    """
+    time = Column(Time(timezone=True))
+    elevation = Column(Float)
+    geom = Column(Geometry("POINT"))

--- a/snowexsql/tables/site.py
+++ b/snowexsql/tables/site.py
@@ -1,18 +1,12 @@
-# -*- coding: utf-8 -*-
-"""
-Created on Thu Aug 22 11:56:34 2024
-
-@author: jtmaz
-"""
-
 from sqlalchemy import Column, String, Date, Float, Integer, ForeignKey
 from sqlalchemy.orm import Mapped, relationship, mapped_column
 from typing import List
 
-from .observers import Observer
-from .base import Base, SingleLocationData
+from .base import Base
 from .campaign import InCampaign
 from .doi import HasDOI
+from .observers import Observer
+from .single_location import SingleLocationData
 
 
 class SiteObservers(Base):

--- a/tests/api/test_layer_measurements.py
+++ b/tests/api/test_layer_measurements.py
@@ -16,7 +16,7 @@ class TestLayerMeasurements(DBConnection):
 
     def test_all_types(self, clz):
         result = clz().all_types
-        assert result == ["depth", "density"]
+        assert result == ["density"]
 
     def test_all_site_names(self, clz):
         result = clz().all_site_names

--- a/tests/api/test_point_measurements.py
+++ b/tests/api/test_point_measurements.py
@@ -1,78 +1,168 @@
-from datetime import date
+"""
+Test the Point Measurement class
+"""
+from datetime import date, timedelta
 
 import geopandas as gpd
-import numpy as np
 import pytest
+from geoalchemy2.shape import to_shape
 
 from snowexsql.api import PointMeasurements
-from tests import DBConnection
+from snowexsql.tables import PointData
 
 
-class TestPointMeasurements(DBConnection):
-    """
-    Test the Point Measurement class
-    """
-    CLZ = PointMeasurements
+@pytest.fixture
+def point_data_x_y(point_data_factory):
+    return to_shape(point_data_factory.build().geom)
 
-    def test_all_types(self, clz):
-        result = clz().all_types
-        assert result == ['depth', 'density']
 
-    def test_all_site_names(self, clz):
-        result = clz().all_site_names
-        assert result == ['Grand Mesa']
+@pytest.fixture
+def point_data_srid(point_data_factory):
+    return point_data_factory.build().geom.srid
 
-    def test_all_dates(self, clz):
-        result = clz().all_dates
-        assert len(result) == 1
 
-    def test_all_observers(self, clz):
-        result = clz().all_observers
-        assert result == ['TEST']
+@pytest.fixture
+def point_data(point_data_factory, db_session):
+    point_data_factory.create()
+    return db_session.query(PointData).all()
 
-    def test_all_instruments(self, clz):
-        result = clz().all_instruments
-        assert result == ["magnaprobe"]
 
-    def test_all_dois(self, clz):
-        result = clz().all_dois
-        assert result == ['fake_doi', 'fake_doi2']
+@pytest.mark.usefixtures("db_test_session")
+@pytest.mark.usefixtures("db_test_connection")
+@pytest.mark.usefixtures("point_data")
+class TestPointMeasurements:
+    @pytest.fixture(autouse=True)
+    def setup_method(self, point_data):
+        self.subject = PointMeasurements()
+        self.db_data = point_data
 
-    @pytest.mark.parametrize(
-        "kwargs, expected_length, mean_value", [
-            ({
-                 "date": date(2020, 5, 28),
-                 "instrument": 'camera'
-             }, 0, np.nan),
-            ({"instrument": "magnaprobe", "limit": 10}, 1, 94.0),
-            # limit works
-            ({
-                 "date": date(2020, 5, 28),
-                 "instrument": 'pit ruler'
-             }, 0, np.nan),
-            ({
-                 "date_less_equal": date(2019, 10, 1),
-             }, 0, np.nan),
-            ({
-                 "date_greater_equal": date(2020, 6, 7),
-             }, 0, np.nan),
-            ({
-                 "doi": "fake_doi",
-             }, 1, 94.0),
-            ({
-                 "type": 'depth',
-             }, 1, 94.0),
-            ({
-                 "observer": 'TEST',
-                 "campaign": 'Grand Mesa'
-             }, 1, 94.0),
+    def test_all_types(self):
+        result = self.subject.all_types
+        assert result == [
+            record.observation.measurement_type.name
+            for record in self.db_data
         ]
-    )
-    def test_from_filter(self, clz, kwargs, expected_length, mean_value):
-        result = clz.from_filter(**kwargs)
-        assert len(result) == expected_length
-        if expected_length > 0:
-            assert pytest.approx(result["value"].mean()) == mean_value
+
+    def test_all_site_names(self):
+        result = self.subject.all_site_names
+        assert result == [
+            record.observation.campaign.name
+            for record in self.db_data
+        ]
+
+    def test_all_dates(self):
+        result = self.subject.all_dates
+        assert result == [
+            record.date
+            for record in self.db_data
+        ]
+
+    def test_all_observers(self):
+        result = self.subject.all_observers
+        assert result == [
+            record.observation.observer.name
+            for record in self.db_data
+        ]
+
+    def test_all_instruments(self):
+        result = self.subject.all_instruments
+        assert result == [
+            record.observation.instrument.name
+            for record in self.db_data
+        ]
+
+    def test_all_dois(self):
+        result = self.subject.all_dois
+        assert result == [
+            record.observation.doi.doi
+            for record in self.db_data
+        ]
+
+
+@pytest.mark.usefixtures("db_test_session")
+@pytest.mark.usefixtures("db_test_connection")
+@pytest.mark.usefixtures("point_data")
+class TestPointMeasurementFilter:
+    @pytest.fixture(autouse=True)
+    def setup_method(self, point_data):
+        self.subject = PointMeasurements()
+        # Pick the first record for this test case
+        self.db_data = point_data[0]
+
+    def test_date_and_instrument(self):
+        result = self.subject.from_filter(
+            date=self.db_data.date.date(),
+            instrument=self.db_data.observation.instrument.name,
+        )
+        assert len(result) == 1
+        assert result.loc[0].value == self.db_data.value
+
+    def test_instrument_and_limit(self, point_data_factory):
+        # Create 10 more records, but only fetch five
+        point_data_factory.create_batch(10)
+
+        result = self.subject.from_filter(
+            instrument=self.db_data.observation.instrument.name,
+            limit=5
+        )
+        assert len(result) == 5
+        assert pytest.approx(result["value"].mean()) == self.db_data.value
+
+    def test_no_instrument_on_date(self):
+        result = self.subject.from_filter(
+            date=self.db_data.date.date() + timedelta(days=1),
+            instrument=self.db_data.observation.instrument.name,
+        )
+        assert len(result) == 0
+
+    def test_unknown_instrument(self):
+        result = self.subject.from_filter(
+            instrument='Does not exist',
+        )
+        assert len(result) == 0
+
+    def test_date_and_measurement_type(self):
+        result = self.subject.from_filter(
+            date=self.db_data.date.date(),
+            type=self.db_data.observation.measurement_type.name,
+        )
+        assert len(result) == 1
+        assert result.loc[0].value == self.db_data.value
+
+    def test_doi(self):
+        result = self.subject.from_filter(
+            doi=self.db_data.observation.doi.doi,
+        )
+        assert len(result) == 1
+        assert result.loc[0].value == self.db_data.value
+
+    def test_observer_in_campaign(self):
+        result = self.subject.from_filter(
+            observer=self.db_data.observation.observer.name,
+            campaign=self.db_data.observation.campaign.name,
+        )
+        assert len(result) == 1
+        assert result.loc[0].value == self.db_data.value
+
+    def test_date_less_equal(self, point_data_factory):
+        greater_date = self.db_data.date.date() + timedelta(days=1)
+        point_data_factory.create(date=greater_date)
+
+        result = self.subject.from_filter(
+            date_less_equal=self.db_data.date.date(),
+        )
+        assert len(result) == 1
+        assert result.loc[0].value == self.db_data.value
+
+    def test_date_greater_equal(self, point_data_factory):
+        greater_date = self.db_data.date.date() - timedelta(days=1)
+        point_data_factory.create(date=greater_date)
+
+        result = self.subject.from_filter(
+            date_greater_equal=self.db_data.date.date(),
+        )
+        assert len(result) == 1
+        assert result.loc[0].value == self.db_data.value
 
     @pytest.mark.parametrize(
         "kwargs, expected_error", [
@@ -81,28 +171,27 @@ class TestPointMeasurements(DBConnection):
             ({"date": [date(2020, 5, 28), date(2019, 10, 3)]}, ValueError),
         ]
     )
-    def test_from_filter_fails(self, clz, kwargs, expected_error):
+    def test_from_filter_fails(self, kwargs, expected_error):
         """
         Test failure on not-allowed key and too many returns
         """
         with pytest.raises(expected_error):
-            clz.from_filter(**kwargs)
+            self.subject.from_filter(**kwargs)
 
-    def test_from_area(self, clz):
+    def test_from_area(self, point_data_x_y, point_data_srid):
         shp = gpd.points_from_xy(
-            [743766.4794971556], [4321444.154620216], crs="epsg:26912"
+            [point_data_x_y.x],
+            [point_data_x_y.y],
+            crs=f"epsg:{point_data_srid}"
         ).buffer(10)[0]
-        result = clz.from_area(
-            shp=shp,
-            date=date(2019, 10, 30)
-        )
-        assert len(result) == 0
+        result = self.subject.from_area(shp=shp)
+        assert len(result) == 1
 
-    def test_from_area_point(self, clz):
-        pts = gpd.points_from_xy([743766.4794971556], [4321444.154620216])
-        crs = "26912"
-        result = clz.from_area(
-            pt=pts[0], buffer=10, crs=crs,
-            date=date(2019, 10, 30)
+    def test_from_area_point(self, point_data_x_y, point_data_srid):
+        pts = gpd.points_from_xy(
+            [point_data_x_y.x],
+            [point_data_x_y.y],
         )
-        assert len(result) == 0
+        crs = point_data_srid
+        result = self.subject.from_area(pt=pts[0], buffer=10, crs=crs)
+        assert len(result) == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,58 @@
+import pytest
+from pytest_factoryboy import register
+from sqlalchemy import create_engine
+
+from snowexsql.db import db_connection_string, initialize
+from tests.factories import (
+    CampaignFactory, DOIFactory, InstrumentFactory, MeasurementTypeFactory,
+    ObserverFactory, PointDataFactory, PointObservationFactory
+)
+from .db_setup import CREDENTIAL_FILE, DB_INFO, SESSION
+
+# Make factories available to tests
+register(CampaignFactory)
+register(DOIFactory)
+register(InstrumentFactory)
+register(MeasurementTypeFactory)
+register(ObserverFactory)
+register(PointDataFactory)
+register(PointObservationFactory)
+
+
+@pytest.fixture(scope="session")
+def connection():
+    database_name = DB_INFO["address"] + "/" + DB_INFO["db_name"]
+    db_string = db_connection_string(database_name, CREDENTIAL_FILE)
+
+    engine = create_engine(db_string)
+    initialize(engine)
+    connection = engine.connect()
+
+    yield connection
+
+    connection.close()
+    engine.dispose()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def db_session(connection):
+    # Based on:
+    # https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#joining-a-session-into-an-external-transaction-such-as-for-test-suites
+
+    transaction = connection.begin()
+
+    # Configure session
+    SESSION.configure(
+        bind=connection, join_transaction_mode="create_savepoint"
+    )
+
+    # Create a new session
+    session = SESSION()
+
+    yield session
+
+    # rollback
+    # Everything that happened with the Session above
+    # (including calls to commit()) are rolled back.
+    session.close()
+    transaction.rollback()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
+import os
+from contextlib import contextmanager
+
 import pytest
 from pytest_factoryboy import register
 from sqlalchemy import create_engine
 
+import snowexsql
 from snowexsql.db import db_connection_string, initialize
 from tests.factories import (
     CampaignFactory, DOIFactory, InstrumentFactory, MeasurementTypeFactory,
@@ -21,6 +25,12 @@ register(PointObservationFactory)
 
 @pytest.fixture(scope="session")
 def connection():
+# Add this factory to a test if you would like to debug the SQL statement
+# It will print the query from the BaseDataset.from_filter() method
+@pytest.fixture(scope='session')
+def _debug_sql_query():
+    os.environ['DEBUG_QUERY'] = '1'
+
     database_name = DB_INFO["address"] + "/" + DB_INFO["db_name"]
     db_string = db_connection_string(database_name, CREDENTIAL_FILE)
 

--- a/tests/db_connection.py
+++ b/tests/db_connection.py
@@ -7,7 +7,7 @@ from snowexsql.api import (
     PointMeasurements, db_session
 )
 from snowexsql.tables import DOI, Instrument, LayerData, MeasurementType, \
-    Observer, PointData, Site
+    Observer, Site
 from snowexsql.tables.campaign import Campaign
 from .db_setup import DBSetup
 
@@ -116,27 +116,6 @@ class DBConnection(DBSetup):
             session.commit()
 
     @pytest.fixture(scope="class")
-    def populated_points(self, db):
-        # Add made up data at the initialization of the class
-        row = {
-            'date': date(2020, 1, 28),
-            'time': time(18, 48),
-            'elevation': 3148.2,
-            'equipment': 'CRREL_B',
-            'version_number': 1,
-            'geom': WKTElement(
-                "POINT(747987.6190615438 4324061.7062127385)", srid=26912
-            ),
-            'value': 94
-        }
-        self._add_entry(
-            db.url, PointData, 'magnaprobe', ["TEST"],
-            'Grand Mesa', None,
-            "fake_doi", "depth",
-            **row
-        )
-
-    @pytest.fixture(scope="class")
     def populated_layer(self, db):
         # Fake data to implement
         row = {
@@ -156,7 +135,7 @@ class DBConnection(DBSetup):
         )
 
     @pytest.fixture(scope="class")
-    def clz(self, populated_points, populated_layer):
+    def clz(self, populated_layer):
         """
         Extend the class and overwrite the database name
         """

--- a/tests/db_connection.py
+++ b/tests/db_connection.py
@@ -98,7 +98,9 @@ class DBConnection(DBSetup):
             )
 
             object_kwargs = dict(
-                instrument=instrument, doi=doi, measurement=measurement_obj,
+                instrument=instrument,
+                doi=doi,
+                measurement_type=measurement_obj,
                 **kwargs
             )
             # Add site if given

--- a/tests/db_setup.py
+++ b/tests/db_setup.py
@@ -1,7 +1,14 @@
 import json
 from os.path import dirname, join
 
+from sqlalchemy import orm
+
 from snowexsql.db import get_db, initialize
+
+# DB Configuration and Session
+CREDENTIAL_FILE = join(dirname(__file__), 'credentials.json')
+DB_INFO = json.load(open(CREDENTIAL_FILE))
+SESSION = orm.scoped_session(orm.sessionmaker())
 
 
 class DBSetup:
@@ -9,8 +16,8 @@ class DBSetup:
     Base class for all our tests. Ensures that we clean up after every class
     that's run
     """
-    CREDENTIAL_FILE = join(dirname(__file__), 'credentials.json')
-    DB_INFO = json.load(open(CREDENTIAL_FILE))
+    CREDENTIAL_FILE = CREDENTIAL_FILE
+    DB_INFO = DB_INFO
 
     @classmethod
     def database_name(cls):

--- a/tests/db_setup.py
+++ b/tests/db_setup.py
@@ -4,6 +4,9 @@ from os.path import dirname, join
 from sqlalchemy import orm
 
 from snowexsql.db import get_db, initialize
+from snowexsql.tables import (Campaign, DOI, Instrument, LayerData,
+                              MeasurementType, Observer, Site)
+from snowexsql.tables.site import SiteObservers
 
 # DB Configuration and Session
 CREDENTIAL_FILE = join(dirname(__file__), 'credentials.json')
@@ -44,6 +47,18 @@ class DBSetup:
         NOTE: Not dropping the DB since this is done at every test class
               initialization
         """
+        # TODO - Hack to make different data loading methods co-exist
+        #        Remove this once we switch all to using factory boy
+        cls.session.query(LayerData).delete()
+        cls.session.query(SiteObservers).delete()
+        cls.session.query(Observer).delete()
+        cls.session.query(Site).delete()
+        cls.session.query(Instrument).delete()
+        cls.session.query(Campaign).delete()
+        cls.session.query(DOI).delete()
+        cls.session.query(MeasurementType).delete()
+        cls.session.commit()
+
         cls.session.flush()
         cls.session.rollback()
         cls.session.close()

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,0 +1,17 @@
+from .campaign import CampaignFactory
+from .doi import DOIFactory
+from .instrument import InstrumentFactory
+from .measurement_type import MeasurementTypeFactory
+from .observer import ObserverFactory
+from .point_data import PointDataFactory
+from .point_observation import PointObservationFactory
+
+__all__ = [
+    "CampaignFactory",
+    "DOIFactory",
+    "InstrumentFactory",
+    "MeasurementTypeFactory",
+    "ObserverFactory",
+    "PointDataFactory",
+    "PointObservationFactory",
+]

--- a/tests/factories/base_factory.py
+++ b/tests/factories/base_factory.py
@@ -6,4 +6,4 @@ from tests.db_setup import SESSION
 class BaseFactory(factory_alchemy.SQLAlchemyModelFactory):
     class Meta:
         sqlalchemy_session = SESSION
-        sqlalchemy_session_persistence = 'flush'
+        sqlalchemy_session_persistence = 'commit'

--- a/tests/factories/base_factory.py
+++ b/tests/factories/base_factory.py
@@ -1,0 +1,9 @@
+import factory.alchemy as factory_alchemy
+
+from tests.db_setup import SESSION
+
+
+class BaseFactory(factory_alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        sqlalchemy_session = SESSION
+        sqlalchemy_session_persistence = 'flush'

--- a/tests/factories/campaign.py
+++ b/tests/factories/campaign.py
@@ -1,0 +1,11 @@
+from snowexsql.tables import Campaign
+
+from .base_factory import BaseFactory
+
+
+class CampaignFactory(BaseFactory):
+    class Meta:
+        model = Campaign
+
+    name = 'Snow Campaign'
+    description = 'Snow Campaign Description'

--- a/tests/factories/doi.py
+++ b/tests/factories/doi.py
@@ -1,0 +1,14 @@
+import datetime
+
+import factory
+
+from snowexsql.tables import DOI
+from .base_factory import BaseFactory
+
+
+class DOIFactory(BaseFactory):
+    class Meta:
+        model = DOI
+
+    doi = '111-222'
+    date_accessed = factory.LazyFunction(datetime.date.today)

--- a/tests/factories/instrument.py
+++ b/tests/factories/instrument.py
@@ -1,0 +1,11 @@
+from snowexsql.tables import Instrument
+from .base_factory import BaseFactory
+
+
+class InstrumentFactory(BaseFactory):
+    class Meta:
+        model = Instrument
+
+    name = 'SWE Instrument'
+    model = 'Instrument Model'
+    specifications = 'Measures SWE well'

--- a/tests/factories/measurement_type.py
+++ b/tests/factories/measurement_type.py
@@ -1,0 +1,10 @@
+from snowexsql.tables import MeasurementType
+from .base_factory import BaseFactory
+
+
+class MeasurementTypeFactory(BaseFactory):
+    class Meta:
+        model = MeasurementType
+
+    name = 'SWE'
+    units = 'mm'

--- a/tests/factories/observer.py
+++ b/tests/factories/observer.py
@@ -1,0 +1,11 @@
+import factory
+
+from snowexsql.tables import Observer
+from .base_factory import BaseFactory
+
+
+class ObserverFactory(BaseFactory):
+    class Meta:
+        model = Observer
+
+    name = factory.Faker('name')

--- a/tests/factories/point_data.py
+++ b/tests/factories/point_data.py
@@ -1,6 +1,7 @@
 import datetime
 
 import factory
+from geoalchemy2 import WKTElement
 
 from snowexsql.tables import PointData
 from .base_factory import BaseFactory
@@ -13,5 +14,10 @@ class PointDataFactory(BaseFactory):
 
     value = 10
     date = factory.LazyFunction(datetime.datetime.now)
+
+    geom = WKTElement(
+        "POINT(747987.6190615438 4324061.7062127385)", srid=26912
+    )
+    elevation = 3148.2
 
     observation = factory.SubFactory(PointObservationFactory)

--- a/tests/factories/point_data.py
+++ b/tests/factories/point_data.py
@@ -1,0 +1,17 @@
+import datetime
+
+import factory
+
+from snowexsql.tables import PointData
+from .base_factory import BaseFactory
+from .point_observation import PointObservationFactory
+
+
+class PointDataFactory(BaseFactory):
+    class Meta:
+        model = PointData
+
+    value = 10
+    date = factory.LazyFunction(datetime.datetime.now)
+
+    observation = factory.SubFactory(PointObservationFactory)

--- a/tests/factories/point_observation.py
+++ b/tests/factories/point_observation.py
@@ -1,0 +1,23 @@
+import factory
+
+from snowexsql.tables.point_observation import PointObservation
+from .base_factory import BaseFactory
+from .campaign import CampaignFactory
+from .doi import DOIFactory
+from .instrument import InstrumentFactory
+from .measurement_type import MeasurementTypeFactory
+from .observer import ObserverFactory
+
+
+class PointObservationFactory(BaseFactory):
+    class Meta:
+        model = PointObservation
+
+    name = 'Point Observation'
+    description = 'Point Description'
+
+    campaign = factory.SubFactory(CampaignFactory)
+    doi = factory.SubFactory(DOIFactory)
+    instrument = factory.SubFactory(InstrumentFactory)
+    measurement = factory.SubFactory(MeasurementTypeFactory)
+    observer = factory.SubFactory(ObserverFactory)

--- a/tests/factories/point_observation.py
+++ b/tests/factories/point_observation.py
@@ -19,5 +19,5 @@ class PointObservationFactory(BaseFactory):
     campaign = factory.SubFactory(CampaignFactory)
     doi = factory.SubFactory(DOIFactory)
     instrument = factory.SubFactory(InstrumentFactory)
-    measurement = factory.SubFactory(MeasurementTypeFactory)
+    measurement_type = factory.SubFactory(MeasurementTypeFactory)
     observer = factory.SubFactory(ObserverFactory)

--- a/tests/factories/point_observation.py
+++ b/tests/factories/point_observation.py
@@ -1,3 +1,5 @@
+import datetime
+
 import factory
 
 from snowexsql.tables.point_observation import PointObservation
@@ -15,6 +17,7 @@ class PointObservationFactory(BaseFactory):
 
     name = 'Point Observation'
     description = 'Point Description'
+    date = factory.LazyFunction(datetime.date.today)
 
     campaign = factory.SubFactory(CampaignFactory)
     doi = factory.SubFactory(DOIFactory)

--- a/tests/tables/test_campaign.py
+++ b/tests/tables/test_campaign.py
@@ -1,0 +1,21 @@
+import pytest
+
+from snowexsql.tables import Campaign
+
+
+@pytest.fixture
+def campaign_record(campaign_factory, db_session):
+    campaign_factory.create()
+    return db_session.query(Campaign).first()
+
+
+class TestCampaign:
+    @pytest.fixture(autouse=True)
+    def setup_method(self, campaign_record):
+        self.subject = campaign_record
+
+    def test_campaign_name(self, campaign_factory):
+        assert self.subject.name == campaign_factory.name
+
+    def test_campaign_description(self, campaign_factory):
+        assert self.subject.description == campaign_factory.description

--- a/tests/tables/test_doi.py
+++ b/tests/tables/test_doi.py
@@ -1,0 +1,23 @@
+from datetime import date
+
+import pytest
+
+from snowexsql.tables import DOI
+
+
+@pytest.fixture
+def doi_record(doi_factory, db_session):
+    doi_factory.create()
+    return db_session.query(DOI).first()
+
+
+class TestDOI:
+    @pytest.fixture(autouse=True)
+    def setup_method(self, doi_record):
+        self.subject = doi_record
+
+    def test_doi(self, doi_factory):
+        assert self.subject.doi == doi_factory.doi
+
+    def test_date_accessed(self):
+        assert type(self.subject.date_accessed) is date

--- a/tests/tables/test_instrument.py
+++ b/tests/tables/test_instrument.py
@@ -1,0 +1,26 @@
+import pytest
+
+from snowexsql.tables import Instrument
+
+
+@pytest.fixture
+def instrument_record(instrument_factory, db_session):
+    instrument_factory.create()
+    return db_session.query(Instrument).first()
+
+
+class TestInstrument:
+    @pytest.fixture(autouse=True)
+    def setup_method(self, instrument_record):
+        self.subject = instrument_record
+
+    def test_instrument_name(self, instrument_factory):
+        assert self.subject.name == instrument_factory.name
+
+    def test_instrument_model(self, instrument_factory):
+        assert self.subject.model == instrument_factory.model
+
+    def test_instrument_specification(self, instrument_factory):
+        assert (
+            self.subject.specifications == instrument_factory.specifications
+        )

--- a/tests/tables/test_measurment_type.py
+++ b/tests/tables/test_measurment_type.py
@@ -1,0 +1,21 @@
+import pytest
+
+from snowexsql.tables import MeasurementType
+
+
+@pytest.fixture
+def measurement_type_record(measurement_type_factory, db_session):
+    measurement_type_factory.create()
+    return db_session.query(MeasurementType).first()
+
+
+class TestMeasurementType:
+    @pytest.fixture(autouse=True)
+    def setup_method(self, measurement_type_record):
+        self.subject = measurement_type_record
+
+    def test_measurement_type_name(self, measurement_type_factory):
+        assert self.subject.name == measurement_type_factory.name
+
+    def test_measurement_type_unit(self, measurement_type_factory):
+        assert self.subject.units == measurement_type_factory.units

--- a/tests/tables/test_observer.py
+++ b/tests/tables/test_observer.py
@@ -1,0 +1,18 @@
+import pytest
+
+from snowexsql.tables import Observer
+
+
+@pytest.fixture
+def observer_record(observer_factory, db_session):
+    observer_factory.create()
+    return db_session.query(Observer).first()
+
+
+class TestObserver:
+    @pytest.fixture(autouse=True)
+    def setup_method(self, observer_record):
+        self.subject = observer_record
+
+    def test_observer_name(self):
+        assert type(self.subject.name) is str

--- a/tests/tables/test_point_data.py
+++ b/tests/tables/test_point_data.py
@@ -1,0 +1,26 @@
+from datetime import date
+
+import pytest
+
+from snowexsql.tables import PointData
+
+
+@pytest.fixture
+def point_entry_record(point_data_factory, db_session):
+    point_data_factory.create()
+    return db_session.query(PointData).first()
+
+
+class TestPointData:
+    @pytest.fixture(autouse=True)
+    def setup_method(self, point_entry_record):
+        self.subject = point_entry_record
+
+    def test_record_id(self):
+        assert self.subject.id is not None
+
+    def test_value_attribute(self):
+        assert type(self.subject.value) is float
+
+    def test_date_attribute(self):
+        assert type(self.subject.date) is date

--- a/tests/tables/test_point_data.py
+++ b/tests/tables/test_point_data.py
@@ -24,7 +24,10 @@ class TestPointData:
         assert type(self.subject.value) is float
 
     def test_date_attribute(self):
-        assert type(self.subject.date) is date
+        assert type(self.subject.date) is datetime
+
+    def test_date_only_attribute(self):
+        assert type(self.subject.date_only) is date
 
     def test_elevation_attribute(self, point_data_factory):
         assert self.subject.elevation == point_data_factory.elevation

--- a/tests/tables/test_point_data.py
+++ b/tests/tables/test_point_data.py
@@ -1,6 +1,7 @@
-from datetime import date
+from datetime import date, datetime
 
 import pytest
+from geoalchemy2 import WKBElement
 
 from snowexsql.tables import PointData
 
@@ -24,3 +25,9 @@ class TestPointData:
 
     def test_date_attribute(self):
         assert type(self.subject.date) is date
+
+    def test_elevation_attribute(self, point_data_factory):
+        assert self.subject.elevation == point_data_factory.elevation
+
+    def test_geom_attribute(self):
+        assert isinstance(self.subject.geom, WKBElement)

--- a/tests/tables/test_point_observation.py
+++ b/tests/tables/test_point_observation.py
@@ -16,10 +16,10 @@ class TestPointObservation:
     def setup_method(self, point_observation_record):
         self.subject = point_observation_record
 
-    def test_point_observation_name(self, point_observation_factory):
+    def test_name_attribute(self, point_observation_factory):
         assert self.subject.name == point_observation_factory.name
 
-    def test_point_observation_description(self, point_observation_factory):
+    def test_description_attribute(self, point_observation_factory):
         assert (
             self.subject.description == point_observation_factory.description
         )

--- a/tests/tables/test_point_observation.py
+++ b/tests/tables/test_point_observation.py
@@ -33,8 +33,8 @@ class TestPointObservation:
         assert isinstance(self.subject.doi, DOI)
 
     def test_has_measurement_type(self):
-        assert self.subject.measurement is not None
-        assert isinstance(self.subject.measurement, MeasurementType)
+        assert self.subject.measurement_type is not None
+        assert isinstance(self.subject.measurement_type, MeasurementType)
 
     def test_has_instrument(self):
         assert self.subject.instrument is not None

--- a/tests/tables/test_point_observation.py
+++ b/tests/tables/test_point_observation.py
@@ -1,0 +1,45 @@
+import pytest
+
+from snowexsql.tables import (
+    Campaign, DOI, Instrument, MeasurementType, Observer, PointObservation
+)
+
+
+@pytest.fixture
+def point_observation_record(point_observation_factory, db_session):
+    point_observation_factory.create()
+    return db_session.query(PointObservation).first()
+
+
+class TestPointObservation:
+    @pytest.fixture(autouse=True)
+    def setup_method(self, point_observation_record):
+        self.subject = point_observation_record
+
+    def test_point_observation_name(self, point_observation_factory):
+        assert self.subject.name == point_observation_factory.name
+
+    def test_point_observation_description(self, point_observation_factory):
+        assert (
+            self.subject.description == point_observation_factory.description
+        )
+
+    def test_in_campaign(self):
+        assert self.subject.campaign is not None
+        assert isinstance(self.subject.campaign, Campaign)
+
+    def test_has_doi(self):
+        assert self.subject.doi is not None
+        assert isinstance(self.subject.doi, DOI)
+
+    def test_has_measurement_type(self):
+        assert self.subject.measurement is not None
+        assert isinstance(self.subject.measurement, MeasurementType)
+
+    def test_has_instrument(self):
+        assert self.subject.instrument is not None
+        assert isinstance(self.subject.instrument, Instrument)
+
+    def test_has_observer(self):
+        assert self.subject.observer is not None
+        assert isinstance(self.subject.observer, Observer)

--- a/tests/tables/test_point_observation.py
+++ b/tests/tables/test_point_observation.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 
 from snowexsql.tables import (
@@ -23,6 +25,9 @@ class TestPointObservation:
         assert (
             self.subject.description == point_observation_factory.description
         )
+
+    def test_date_attribute(self):
+        assert type(self.subject.date) is datetime.date
 
     def test_in_campaign(self):
         assert self.subject.campaign is not None

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,7 +1,11 @@
 import pytest
-from sqlalchemy import Table
+from sqlalchemy import Engine, MetaData, Table
+from sqlalchemy.orm import Session
 
-from snowexsql.db import get_db, get_table_attributes
+from snowexsql.db import (
+    DB_CONNECTION_PROTOCOL, db_connection_string, get_db, get_table_attributes,
+    load_credentials
+)
 from snowexsql.tables import ImageData, LayerData, PointData, Site, \
     MeasurementType, DOI
 from .db_setup import DBSetup
@@ -59,7 +63,7 @@ class TestDB(DBSetup):
             assert c in columns
 
     @pytest.mark.parametrize(
-        "DataCls,attributes", 
+        "DataCls,attributes",
         [
             (Site, site_atts),
             (PointData, point_atts),
@@ -79,20 +83,54 @@ class TestDB(DBSetup):
             assert c in atts
 
 
-# Independent Tests
-@pytest.mark.parametrize("return_metadata, expected_objs", [
-    (False, 2),
-    (True, 3)])
-def test_getting_db(return_metadata, expected_objs):
-    """
-    Test we can receive a connection and opt out of getting the metadata
-    """
+class TestDBConnectionInfo:
+    def test_load_credentials(self):
+        user, password = load_credentials(DBSetup.CREDENTIAL_FILE)
+        assert user == 'builder'
+        assert password == 'db_builder'
 
-    db_name = (
-            DBSetup.DB_INFO["username"] + ":" +
-            DBSetup.DB_INFO["password"] + "@" +
-            DBSetup.database_name()
-    )
+    def test_db_connection_string(self):
+        db_string = db_connection_string(
+            DBSetup.database_name(), DBSetup.CREDENTIAL_FILE
+        )
+        assert db_string.startswith(DB_CONNECTION_PROTOCOL)
 
-    result = get_db(db_name, return_metadata=return_metadata)
-    assert len(result) == expected_objs
+    def test_db_connection_string_credentials(self):
+        db_string = db_connection_string(
+            DBSetup.database_name(), DBSetup.CREDENTIAL_FILE
+        )
+        user, password = load_credentials(DBSetup.CREDENTIAL_FILE)
+
+        assert user in db_string
+        assert password in db_string
+
+    def test_db_connection_string_no_credentials(self):
+        db_string = db_connection_string(DBSetup.database_name())
+        user, password = load_credentials(DBSetup.CREDENTIAL_FILE)
+
+        assert user not in db_string
+        assert password not in db_string
+
+    def test_returns_engine(self):
+        assert isinstance(get_db(DBSetup.database_name())[0], Engine)
+
+    def test_returns_session(self):
+        assert isinstance(get_db(DBSetup.database_name())[1], Session)
+
+    def test_returns_metadata(self):
+        assert isinstance(
+            get_db(DBSetup.database_name(), return_metadata=True)[2],
+            MetaData
+        )
+
+    @pytest.mark.parametrize("return_metadata, expected_objs", [
+        (False, 2),
+        (True, 3)])
+    def test_get_metadata(self, return_metadata, expected_objs):
+        """
+        Test we can receive a connection and opt out of getting the metadata
+        """
+        result = get_db(
+            DBSetup.database_name(), return_metadata=return_metadata
+        )
+        assert len(result) == expected_objs

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6,13 +6,11 @@ from snowexsql.db import (
     DB_CONNECTION_PROTOCOL, db_connection_string, get_db, get_table_attributes,
     load_credentials
 )
-from snowexsql.tables import ImageData, LayerData, PointData, Site, \
-    MeasurementType, DOI
+from snowexsql.tables import LayerData, Site
 from .db_setup import DBSetup
 
 
 class TestDB(DBSetup):
-    base_atts = ['date', 'site_id']
     single_loc_atts = ['elevation', 'geom', 'time']
 
     meas_atts = ['measurement_type_id']
@@ -24,15 +22,10 @@ class TestDB(DBSetup):
                  'ground_vegetation', 'vegetation_height',
                  'tree_canopy', 'site_notes']
 
-    point_atts = single_loc_atts + meas_atts + \
-                 ['version_number', 'equipment', 'value', 'instrument_id']
-
     layer_atts = meas_atts + \
                  ['depth', 'value', 'bottom_depth', 'comments', 'sample_a',
                   'sample_b', 'sample_c']
     raster_atts = meas_atts + ['raster', 'description']
-    measurement_types_attributes = ['name', 'units','derived']
-    DOI_attributes = ['doi', 'date_accessed']
 
     def setup_class(self):
         """
@@ -40,17 +33,7 @@ class TestDB(DBSetup):
         """
         super().setup_class()
         # only reflect the tables we will use
-        self.metadata.reflect(self.engine, only=['points', 'layers'])
-
-    def test_point_structure(self):
-        """
-        Tests our tables are in the database
-        """
-        t = Table("points", self.metadata, autoload=True)
-        columns = [m.key for m in t.columns]
-
-        for c in self.point_atts:
-            assert c in columns
+        self.metadata.reflect(self.engine, only=['layers'])
 
     def test_layer_structure(self):
         """
@@ -66,11 +49,7 @@ class TestDB(DBSetup):
         "DataCls,attributes",
         [
             (Site, site_atts),
-            (PointData, point_atts),
             (LayerData, layer_atts),
-            (ImageData, raster_atts),
-            (MeasurementType, measurement_types_attributes),
-            (DOI, DOI_attributes)
         ]
     )
     def test_get_table_attributes(self, DataCls, attributes):


### PR DESCRIPTION
This is quite a big one and refactors the structure around metadata for Point and Image data as discussed in #137 and closes related issues (bottom of this description)

It also updates the test suite to use [factory boy](https://factoryboy.readthedocs.io/en/stable/) along with the [integration into ptytest](https://pytest-factoryboy.readthedocs.io/en/stable/).

I will highlight more major changes in code comments.

Grab yourself a :coffee: (or :beer:) this PR has a lot to unfold.


Close #137
Close #136 
Close #132