### PR TITLE
Issue #128 - rename site and campaign

### DIFF
--- a/snowexsql/api.py
+++ b/snowexsql/api.py
@@ -169,7 +169,7 @@ class BaseDataset:
                         qry = cls._filter_instrument(qry, v)
                     elif k == "campaign":
                         qry = cls._filter_campaign(qry, v)
-                    elif k == "site_id":
+                    elif k == "site":
                         qry = qry.filter(
                             qry_model.site.has(name=v)
                         )
@@ -321,7 +321,7 @@ class BaseDataset:
         return df
 
     @property
-    def all_site_names(self):
+    def all_campaigns(self):
         """
         Return all campaign names
         """
@@ -477,8 +477,8 @@ class LayerMeasurements(BaseDataset):
     """
     MODEL = LayerData
     ALLOWED_QRY_KWARGS = [
-        "campaign", "site_id", "date", "instrument", "observer", "type",
-        "utm_zone", "pit_id", "date_greater_equal", "date_less_equal",
+        "campaign", "site", "date", "instrument", "observer", "type",
+        "utm_zone", "date_greater_equal", "date_less_equal",
         "doi", "value_greater_equal", 'value_less_equal'
     ]
 
@@ -496,7 +496,7 @@ class LayerMeasurements(BaseDataset):
         return qry
 
     @property
-    def all_site_ids(self):
+    def all_sites(self):
         """
         Return all specific site names
         """

--- a/tests/api/test_layer_measurements.py
+++ b/tests/api/test_layer_measurements.py
@@ -18,12 +18,12 @@ class TestLayerMeasurements(DBConnection):
         result = clz().all_types
         assert result == ["density"]
 
-    def test_all_site_names(self, clz):
-        result = clz().all_site_names
+    def test_all_campaigns(self, clz):
+        result = clz().all_campaigns
         assert result == ['Grand Mesa']
 
-    def test_all_site_ids(self, clz):
-        result = clz().all_site_ids
+    def test_all_sites(self, clz):
+        result = clz().all_sites
         assert result == ['Fakepit1']
 
     def test_all_dates(self, clz):
@@ -42,7 +42,7 @@ class TestLayerMeasurements(DBConnection):
         "kwargs, expected_length, mean_value", [
             ({
                  "date": date(2020, 3, 12), "type": "density",
-                 "pit_id": "COERIB_20200312_0938"
+                 "site": "COERIB_20200312_0938"
              }, 0, np.nan),  # filter to 1 pit
             ({"instrument": "IRIS", "limit": 10}, 0, np.nan),  # limit works
             ({

--- a/tests/api/test_point_measurements.py
+++ b/tests/api/test_point_measurements.py
@@ -43,8 +43,8 @@ class TestPointMeasurements:
             for record in self.db_data
         ]
 
-    def test_all_site_names(self):
-        result = self.subject.all_site_names
+    def test_all_campaigns(self):
+        result = self.subject.all_campaigns
         assert result == [
             record.observation.campaign.name
             for record in self.db_data


### PR DESCRIPTION
Using campaign and site instead of site, site_id, pit_id

Now a campaign is the larger area like Grand Mesa
and a site is equivalent to a pit. So site.name is equivalent to pit_id