### PR TITLE
Use datetime instead of start time

### DIFF
--- a/snowexsql/tables/site.py
+++ b/snowexsql/tables/site.py
@@ -53,7 +53,6 @@ class Site(SingleLocationData, Base, InCampaign, HasDOI):
     vegetation_height = Column(String())
     tree_canopy = Column(String())
     site_notes = Column(String())
-    start_time = Column(Time(timezone=True))
     end_time = Column(Time(timezone=True))
 
     @hybrid_property

--- a/tests/db_connection.py
+++ b/tests/db_connection.py
@@ -81,7 +81,6 @@ class DBConnection(DBSetup):
                         geom=kwargs.pop("geom"),
                         elevation=kwargs.pop("elevation"),
                         observers=observer_list,
-                        start_time=kwargs.pop("start_time"),
                         end_time=kwargs.pop("end_time"),
                     )
                 )
@@ -127,7 +126,6 @@ class DBConnection(DBSetup):
             ),
             'depth': 100,
             'value': '42.5',
-            "start_time": "10:32:00",
             "end_time": "10:39:00"
         }
         self._add_entry(

--- a/tests/factories/layer_data.py
+++ b/tests/factories/layer_data.py
@@ -26,6 +26,5 @@ class LayerDataFactory(BaseFactory):
     doi = factory.SubFactory(DOIFactory)
     site = factory.SubFactory(
         SiteFactory,
-        start_time=datetime.time(10, 32, tzinfo=datetime.timezone.utc),
         end_time=datetime.time(10, 39, tzinfo=datetime.timezone.utc)
     )

--- a/tests/factories/site.py
+++ b/tests/factories/site.py
@@ -31,7 +31,6 @@ class SiteFactory(BaseFactory):
     vegetation_height = "None"
     tree_canopy = "Open"
     site_notes = "Site Notes"
-    start_time = time(10, 32, tzinfo=timezone.utc)
     end_time = time(10, 39, tzinfo=timezone.utc)
 
     # Single Location data

--- a/tests/tables/test_layer_data.py
+++ b/tests/tables/test_layer_data.py
@@ -54,11 +54,6 @@ class TestLayerData:
         assert isinstance(self.subject.doi, DOI)
         assert self.subject.doi.doi == self.attributes.doi.doi
 
-    def test_start_time(self):
-        assert self.subject.site.start_time is not None
-        assert isinstance(self.subject.site.start_time, datetime.time)
-        assert self.subject.site.start_time == self.attributes.site.start_time
-
     def test_end_time(self):
         assert self.subject.site.end_time is not None
         assert isinstance(self.subject.site.end_time, datetime.time)

--- a/tests/tables/test_site.py
+++ b/tests/tables/test_site.py
@@ -122,11 +122,6 @@ class TestSite:
         assert isinstance(self.subject.observers, list)
         assert type(self.subject.observers[0]) == Observer
 
-    def test_start_time(self):
-        assert self.subject.start_time is not None
-        assert isinstance(self.subject.start_time, datetime.time)
-        assert self.subject.start_time == self.attributes.start_time
-
     def test_end_time(self):
         assert self.subject.end_time is not None
         assert isinstance(self.subject.end_time, datetime.time)


### PR DESCRIPTION
Store the `start_time` as part of the datetime info in the `Site` table