### PR TITLE
Fix 404 link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Features
 * Useful conversions to pandas and geopandas
 * Lots of examples_
 
-.. _examples: https://snowexsql.readthedocs.io/en/latest/examples.html
+.. _examples: https://snowexsql.readthedocs.io/en/latest/gallery/index.html
 
 
 Installing


### PR DESCRIPTION
Looks like the [gallery](https://snowexsql.readthedocs.io/en/latest/gallery/index.html) is where all the examples are located now.