### PR TITLE
DB credentials - Make lookup failsafe to missing environment variable

### DIFF
--- a/snowexsql/db.py
+++ b/snowexsql/db.py
@@ -51,7 +51,7 @@ def load_credentials(credentials_path=None):
     with open(credentials_path) as file:
         credentials = json.load(file)
 
-        if os.environ['SNOWEXSQL_TESTS']:
+        if os.getenv('SNOWEXSQL_TESTS', False):
             return credentials['tests']
         else:
             return credentials['production']

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import snowexsql
 from snowexsql.db import (DB_CONNECTION_PROTOCOL, db_connection_string,
@@ -36,6 +38,20 @@ class TestDBConnectionInfo:
         assert db_string.startswith(DB_CONNECTION_PROTOCOL)
         assert f"{credentials['username']}:{credentials['password']}" in db_string
         assert f"{credentials['address']}/{credentials['db_name']}" in db_string
+
+    def test_load_credentials_production(self):
+        # Test that a missing environ key will not cause the lookup to fail
+        del os.environ['SNOWEXSQL_TESTS']
+
+        credentials = load_credentials()
+        assert len(credentials.keys()) == 4
+        assert 'address' in credentials
+        assert 'db_name' in credentials
+        assert 'username' in credentials
+        assert 'password' in credentials
+
+        # Set again for subsequent tests
+        os.environ['SNOWEXSQL_TESTS'] = 'True'
 
     @pytest.mark.usefixtures('db_connection_string_patch')
     def test_returns_engine(self, monkeypatch, test_db_info):


### PR DESCRIPTION
Set a default value when trying to lookup values based on an environment variable in tests and default to False.