### PR TITLE
Propose non-unique on name, date with pointobservations name+date combo

### DIFF
--- a/snowexsql/api.py
+++ b/snowexsql/api.py
@@ -134,6 +134,10 @@ class BaseDataset:
                 if "date" in k and cls.MODEL == LayerData:
                     qry = qry.join(LayerData.site)
                     qry_model = Site
+                # Special logic for filtering on date with PointData
+                elif "date" in k and cls.MODEL == PointData:
+                    qry = qry.join(PointData.observation)
+                    qry_model = PointObservation
                 elif cls.MODEL == PointData:
                     qry = qry.join(PointData.observation)
 
@@ -473,6 +477,16 @@ class PointMeasurements(BaseDataset):
             ).all()
         return self.retrieve_single_value_result(result)
 
+    @property
+    def all_dates(self):
+        """
+        Return all distinct dates in the data
+        """
+        with db_session(self.DB_NAME) as (session, engine):
+            qry = session.query(PointObservation.date).distinct()
+            result = qry.all()
+        return self.retrieve_single_value_result(result)
+
 
 class TooManyRastersException(Exception):
     """
@@ -555,7 +569,8 @@ class LayerMeasurements(BaseDataset):
                 MeasurementType.units
             ).distinct().all()
         return self.retrieve_single_value_result(result)
-    
+
+
 class RasterMeasurements(BaseDataset):
     MODEL = ImageData
     ALLOWED_QRY_KWARGS = BaseDataset.ALLOWED_QRY_KWARGS + ['description']

--- a/snowexsql/db.py
+++ b/snowexsql/db.py
@@ -51,7 +51,7 @@ def load_credentials(credentials_path=None):
     with open(credentials_path) as file:
         credentials = json.load(file)
 
-        if os.getenv('SNOWEXSQL_TESTS', True):
+        if os.getenv('SNOWEXSQL_TESTS', False):
             return credentials['tests']
         else:
             return credentials['production']

--- a/snowexsql/db.py
+++ b/snowexsql/db.py
@@ -51,7 +51,7 @@ def load_credentials(credentials_path=None):
     with open(credentials_path) as file:
         credentials = json.load(file)
 
-        if os.getenv('SNOWEXSQL_TESTS', False):
+        if os.getenv('SNOWEXSQL_TESTS', True):
             return credentials['tests']
         else:
             return credentials['production']

--- a/snowexsql/tables/campaign_observation.py
+++ b/snowexsql/tables/campaign_observation.py
@@ -1,4 +1,5 @@
-from sqlalchemy import Column, Date, ForeignKey, String, Text, Index
+from sqlalchemy import Column, Date, ForeignKey, String, Text, Index, DateTime
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base
@@ -22,14 +23,29 @@ class CampaignObservation(
     # Data columns
     name = Column(Text, nullable=False)
     description = Column(Text)
-    date = Column(Date, nullable=False)
+    # Date of the measurement with time
+    datetime = Column(DateTime(timezone=True), nullable=False, index=True)
+
+    @hybrid_property
+    def date(self):
+        """
+        Helper attribute to only query for dates of measurements
+        """
+        return self.datetime.date()
+
+    @date.expression
+    def date(cls):
+        """
+        Helper attribute to only query for dates of measurements
+        """
+        return cls.datetime.cast(Date)
 
     # Single Table Inheritance column
     type = Column(String, nullable=False)
 
     # Index
     __table_args__ = (
-        Index('idx_name_date_unique', 'name', 'date', unique=False),
+        Index('idx_name_date_unique', 'name', 'datetime', unique=True),
     )
 
     __mapper_args__ = {

--- a/snowexsql/tables/campaign_observation.py
+++ b/snowexsql/tables/campaign_observation.py
@@ -29,7 +29,7 @@ class CampaignObservation(
 
     # Index
     __table_args__ = (
-        Index('idx_name_date_unique', 'name', 'date', unique=True),
+        Index('idx_name_date_unique', 'name', 'date', unique=False),
     )
 
     __mapper_args__ = {

--- a/snowexsql/tables/point_data.py
+++ b/snowexsql/tables/point_data.py
@@ -20,17 +20,3 @@ class PointData(Base, SingleLocationData, HasPointObservation):
 
     # bring these in instead of Measurement
     units = Column(String())
-
-    @hybrid_property
-    def date(self):
-        """
-        Helper attribute to only query for dates of measurements
-        """
-        return self.datetime.date()
-
-    @date.expression
-    def date(cls):
-        """
-        Helper attribute to only query for dates of measurements
-        """
-        return cls.datetime.cast(Date)

--- a/snowexsql/tables/single_location.py
+++ b/snowexsql/tables/single_location.py
@@ -1,12 +1,10 @@
 from geoalchemy2 import Geometry
-from sqlalchemy import Column, DateTime, Float
+from sqlalchemy import Column, Float
 
 
 class SingleLocationData:
     """
     Base class for point and layer data
     """
-    # Date of the measurement with time
-    datetime = Column(DateTime(timezone=True), nullable=False, index=True)
     elevation = Column(Float)
     geom = Column(Geometry("POINT"), nullable=False)

--- a/snowexsql/tables/site.py
+++ b/snowexsql/tables/site.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from sqlalchemy import (
-    Column, Date, Float, ForeignKey, Integer, String, Index
+    Column, Date, Float, ForeignKey, Integer, String, Index, DateTime
 )
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -36,6 +36,9 @@ class Site(SingleLocationData, Base, InCampaign, HasDOI):
 
     name = Column(String(), nullable=False)  # This can be pit_id
     description = Column(String())
+
+    # Date of the measurement with time
+    datetime = Column(DateTime(timezone=True), nullable=False, index=True)
 
     # Link the observer
     # id is a mapped column for many-to-many with observers

--- a/tests/api/test_point_measurements.py
+++ b/tests/api/test_point_measurements.py
@@ -53,7 +53,7 @@ class TestPointMeasurements:
     def test_all_dates(self):
         result = self.subject.all_dates
         assert result == [
-            record.date
+            record.observation.date
             for record in self.db_data
         ]
 
@@ -91,7 +91,7 @@ class TestPointMeasurementFilter:
 
     def test_date_and_instrument(self):
         result = self.subject.from_filter(
-            date=self.db_data.datetime.date(),
+            date=self.db_data.observation.date,
             instrument=self.db_data.observation.instrument.name,
         )
         assert len(result) == 1
@@ -110,7 +110,7 @@ class TestPointMeasurementFilter:
 
     def test_no_instrument_on_date(self):
         result = self.subject.from_filter(
-            date=self.db_data.datetime.date() + timedelta(days=1),
+            date=self.db_data.observation.date + timedelta(days=1),
             instrument=self.db_data.observation.instrument.name,
         )
         assert len(result) == 0
@@ -123,7 +123,7 @@ class TestPointMeasurementFilter:
 
     def test_date_and_measurement_type(self):
         result = self.subject.from_filter(
-            date=self.db_data.datetime.date(),
+            date=self.db_data.observation.date,
             type=self.db_data.observation.measurement_type.name,
         )
         assert len(result) == 1
@@ -144,22 +144,23 @@ class TestPointMeasurementFilter:
         assert len(result) == 1
         assert result.loc[0].value == self.db_data.value
 
-    def test_date_less_equal(self, point_data_factory):
-        greater_date = self.db_data.datetime.date() + timedelta(days=1)
-        point_data_factory.create(datetime=greater_date)
+    def test_date_less_equal(self, point_data_factory, point_observation_factory):
+        greater_date = self.db_data.observation.date + timedelta(days=1)
+        obs = point_observation_factory.create(datetime=greater_date)
+        point_data_factory.create(observation=obs)
 
         result = self.subject.from_filter(
-            date_less_equal=self.db_data.datetime.date(),
+            date_less_equal=self.db_data.observation.date,
         )
         assert len(result) == 1
         assert result.loc[0].value == self.db_data.value
 
-    def test_date_greater_equal(self, point_data_factory):
-        greater_date = self.db_data.datetime.date() - timedelta(days=1)
-        point_data_factory.create(datetime=greater_date)
-
+    def test_date_greater_equal(self, point_data_factory, point_observation_factory):
+        greater_date = self.db_data.observation.date - timedelta(days=1)
+        obs = point_observation_factory.create(datetime=greater_date)
+        point_data_factory.create(observation=obs)
         result = self.subject.from_filter(
-            date_greater_equal=self.db_data.datetime.date(),
+            date_greater_equal=self.db_data.observation.date,
         )
         assert len(result) == 1
         assert result.loc[0].value == self.db_data.value

--- a/tests/factories/point_data.py
+++ b/tests/factories/point_data.py
@@ -13,8 +13,6 @@ class PointDataFactory(BaseFactory):
         model = PointData
 
     value = 10
-    datetime = factory.LazyFunction(lambda: datetime.now(timezone.utc))
-
     geom = WKTElement(
         "POINT(747987.6190615438 4324061.7062127385)", srid=26912
     )

--- a/tests/factories/point_observation.py
+++ b/tests/factories/point_observation.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 import factory
 
@@ -17,7 +17,7 @@ class PointObservationFactory(BaseFactory):
 
     name = factory.Sequence(lambda n: f'Point Observation {n}')
     description = 'Point Description'
-    date = factory.LazyFunction(datetime.date.today)
+    datetime = factory.LazyFunction(lambda: datetime.now(timezone.utc))
 
     campaign = factory.SubFactory(CampaignFactory)
     doi = factory.SubFactory(DOIFactory)

--- a/tests/tables/test_point_data.py
+++ b/tests/tables/test_point_data.py
@@ -29,20 +29,6 @@ class TestPointData:
     def test_value_attribute(self):
         assert type(self.subject.value) is float
 
-    def test_datetime_attribute(self):
-        assert type(self.subject.datetime) is datetime
-        # The microseconds won't be the same between the site_attribute
-        # and site_record fixture. Hence only testing the difference being
-        # small. Important to subtract the later from the earlier time as
-        # the timedelta object is incorrect otherwise
-        assert (
-           self.attributes.datetime - self.subject.datetime
-       ).seconds == pytest.approx(0, rel=0.1)
-
-    def test_date_attribute(self):
-        assert type(self.subject.date) is date
-        assert self.subject.date == self.attributes.date
-
     def test_elevation_attribute(self):
         assert self.subject.elevation == self.attributes.elevation
 

--- a/tests/tables/test_point_observation.py
+++ b/tests/tables/test_point_observation.py
@@ -30,6 +30,9 @@ class TestPointObservation:
             self.subject.description == point_observation.description
         )
 
+    def test_datetime_attribute(self):
+        assert type(self.subject.datetime) is datetime.datetime
+
     def test_date_attribute(self):
         assert type(self.subject.date) is datetime.date
 


### PR DESCRIPTION
Going back to this discussion https://github.com/SnowEx/snowexsql/pull/181#discussion_r1951749687

If we use something generic like GPRTransect for names, we will violate the unique name+date index. My proposal is to get rid of the unique requirement and keep the non-null requirements on both. This method should fit the data better.