### PR TITLE
DB - Fix session handling for context method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 dev = [
     "factory_boy<4",
     "pytest-factoryboy<3",
-    "pytest",
+    "pytest<8.4",
     "pytest-cov",
     "sphinx-autobuild<=2024.5",
 ]

--- a/snowexsql/db.py
+++ b/snowexsql/db.py
@@ -22,9 +22,7 @@ DB_CONNECTION_OPTIONS = {"options": "-c timezone=UTC"}
 
 def initialize(engine):
     """
-    Creates the original database from scratch, currently only for
-    point data
-
+    Creates the original database from scratch.
     """
     meta = Base.metadata
     meta.drop_all(bind=engine)
@@ -117,7 +115,10 @@ def db_session_with_credentials(credentials_path=None):
         credentials_path (string): Full path to credentials file (Optional)
 
     """
-    yield get_db(credentials_path)
+    engine, session = get_db(credentials_path)
+    yield engine, session
+    session.close()
+    engine.dispose()
 
 
 def get_table_attributes(DataCls):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -7,6 +7,7 @@ from snowexsql.db import (DB_CONNECTION_PROTOCOL, db_connection_string,
                           load_credentials)
 from sqlalchemy import Engine, MetaData
 from sqlalchemy.orm import Session
+from sqlalchemy import text
 
 
 @pytest.fixture(scope='function')
@@ -75,8 +76,13 @@ class TestDBConnectionInfo:
             engine = test_engine
             session = test_session
 
-        assert isinstance(engine, Engine)
-        assert isinstance(session, Session)
+            assert isinstance(engine, Engine)
+            assert isinstance(session, Session)
+            # Query to create a transaction
+            session.query(text('1')).all()
+
+        # On session.close(), all transactions should be gone
+        assert session._transaction is None
 
     @pytest.mark.usefixtures('db_connection_string_patch')
     @pytest.mark.parametrize("return_metadata, expected_objs", [


### PR DESCRIPTION
The `db_session_with_credentials` helper method did not properly close the active session once a query was executed. This method was first used in the snowex_db library and caused tests to hang when trying to tear down test data between class runs.