### PR TITLE
Tables - Instruments - Remove null constraint on relationship

### DIFF
--- a/snowexsql/tables/instrument.py
+++ b/snowexsql/tables/instrument.py
@@ -22,7 +22,7 @@ class HasInstrument:
         return Column(
             Integer,
             ForeignKey('public.instruments.id'),
-            index=True, nullable=False
+            index=True, nullable=True
         )
 
     @declared_attr


### PR DESCRIPTION
Remving the requirement for an instrument with layers as we not always will have that information. For instance with temperatures or densities.