### PR TITLE
Tables - PointData - Drop version_number, equipment, and units column

### DIFF
--- a/snowexsql/tables/point_data.py
+++ b/snowexsql/tables/point_data.py
@@ -14,12 +14,7 @@ class PointData(Base, SingleLocationData, HasPointObservation):
     """
     __tablename__ = 'points'
 
-    version_number = Column(Integer)
-    equipment = Column(String())
     value = Column(Float, nullable=False)
-
-    # bring these in instead of Measurement
-    units = Column(String())
 
     @hybrid_property
     def date(self):


### PR DESCRIPTION
These attributes all live in other tables and have not been used when updating the DB upload scripts.

Closes #192