### PR TITLE
Measurement type - Move to points and image table

### DIFF
--- a/snowexsql/api.py
+++ b/snowexsql/api.py
@@ -421,16 +421,6 @@ class PointMeasurements(BaseDataset):
         )
 
     @classmethod
-    def _filter_measurement_type(cls, qry, value):
-        return qry.join(
-            cls.MODEL.observation
-        ).join(
-            PointObservation.measurement_type
-        ).filter(
-            MeasurementType.name == value
-        )
-
-    @classmethod
     def _filter_instrument(cls, qry, value):
         return qry.join(
             cls.MODEL.observation

--- a/snowexsql/tables/campaign_observation.py
+++ b/snowexsql/tables/campaign_observation.py
@@ -5,12 +5,11 @@ from .base import Base
 from .campaign import InCampaign
 from .doi import HasDOI
 from .instrument import HasInstrument
-from .measurement_type import HasMeasurementType
 from .observers import HasObserver
 
 
 class CampaignObservation(
-    Base, HasDOI, HasInstrument, HasMeasurementType, HasObserver, InCampaign
+    Base, HasDOI, HasInstrument, HasObserver, InCampaign
 ):
     """
     A campaign observation holds additional information for a point or image.

--- a/snowexsql/tables/image_data.py
+++ b/snowexsql/tables/image_data.py
@@ -3,9 +3,10 @@ from sqlalchemy import Column
 
 from .base import Base
 from .image_observation import HasImageObservation
+from .measurement_type import HasMeasurementType
 
 
-class ImageData(Base, HasImageObservation):
+class ImageData(Base, HasImageObservation, HasMeasurementType):
     """
     Class representing the images table. This table holds all images/rasters
     """

--- a/snowexsql/tables/point_data.py
+++ b/snowexsql/tables/point_data.py
@@ -2,11 +2,14 @@ from sqlalchemy import Column, Date, Float, Integer, String
 from sqlalchemy.ext.hybrid import hybrid_property
 
 from .base import Base
+from .measurement_type import HasMeasurementType
 from .point_observation import HasPointObservation
 from .single_location import SingleLocationData
 
 
-class PointData(Base, SingleLocationData, HasPointObservation):
+class PointData(
+    Base, SingleLocationData, HasPointObservation, HasMeasurementType
+):
     """
     Class representing the points table. This table holds all point data.
     Here a single data entry is a single coordinate pair with a single value

--- a/tests/api/test_point_measurements.py
+++ b/tests/api/test_point_measurements.py
@@ -39,7 +39,7 @@ class TestPointMeasurements:
     def test_all_types(self):
         result = self.subject.all_types
         assert result == [
-            record.observation.measurement_type.name
+            record.measurement_type.name
             for record in self.db_data
         ]
 
@@ -124,7 +124,7 @@ class TestPointMeasurementFilter:
     def test_date_and_measurement_type(self):
         result = self.subject.from_filter(
             date=self.db_data.datetime.date(),
-            type=self.db_data.observation.measurement_type.name,
+            type=self.db_data.measurement_type.name,
         )
         assert len(result) == 1
         assert result.loc[0].value == self.db_data.value

--- a/tests/factories/point_data.py
+++ b/tests/factories/point_data.py
@@ -5,6 +5,7 @@ from geoalchemy2 import WKTElement
 
 from snowexsql.tables import PointData
 from .base_factory import BaseFactory
+from .measurement_type import MeasurementTypeFactory
 from .point_observation import PointObservationFactory
 
 
@@ -21,3 +22,4 @@ class PointDataFactory(BaseFactory):
     elevation = 3148.2
 
     observation = factory.SubFactory(PointObservationFactory)
+    measurement_type = factory.SubFactory(MeasurementTypeFactory)

--- a/tests/factories/point_observation.py
+++ b/tests/factories/point_observation.py
@@ -7,7 +7,6 @@ from .base_factory import BaseFactory
 from .campaign import CampaignFactory
 from .doi import DOIFactory
 from .instrument import InstrumentFactory
-from .measurement_type import MeasurementTypeFactory
 from .observer import ObserverFactory
 
 
@@ -22,5 +21,4 @@ class PointObservationFactory(BaseFactory):
     campaign = factory.SubFactory(CampaignFactory)
     doi = factory.SubFactory(DOIFactory)
     instrument = factory.SubFactory(InstrumentFactory)
-    measurement_type = factory.SubFactory(MeasurementTypeFactory)
     observer = factory.SubFactory(ObserverFactory)

--- a/tests/tables/test_point_data.py
+++ b/tests/tables/test_point_data.py
@@ -3,7 +3,7 @@ from datetime import date, datetime
 import pytest
 from geoalchemy2 import WKBElement
 
-from snowexsql.tables import PointData
+from snowexsql.tables import PointData, MeasurementType
 
 
 @pytest.fixture
@@ -48,3 +48,8 @@ class TestPointData:
 
     def test_geom_attribute(self):
         assert isinstance(self.subject.geom, WKBElement)
+
+    def test_has_measurement_type(self):
+        assert self.subject.measurement_type is not None
+        assert isinstance(self.subject.measurement_type, MeasurementType)
+

--- a/tests/tables/test_point_observation.py
+++ b/tests/tables/test_point_observation.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 
 from snowexsql.tables import (
-    Campaign, DOI, Instrument, MeasurementType, Observer, PointObservation
+    Campaign, DOI, Instrument, Observer, PointObservation
 )
 
 
@@ -40,10 +40,6 @@ class TestPointObservation:
     def test_has_doi(self):
         assert self.subject.doi is not None
         assert isinstance(self.subject.doi, DOI)
-
-    def test_has_measurement_type(self):
-        assert self.subject.measurement_type is not None
-        assert isinstance(self.subject.measurement_type, MeasurementType)
 
     def test_has_instrument(self):
         assert self.subject.instrument is not None


### PR DESCRIPTION
Refactor the schema and move the measurement type from the campaign observation to the image and points table. This allows having multiple measurements per observation.

Closes #194